### PR TITLE
Update ember-cartodb-adapter.js

### DIFF
--- a/ember-cartodb-adapter.js
+++ b/ember-cartodb-adapter.js
@@ -103,7 +103,7 @@ DS.CartoDBAdapter = DS.RESTAdapter.extend({
     query = queryTpl.replace(/{{table}}/g, table);
     if (id) query = query.replace(/{{id}}/g, id);
 
-    url = 'http://' + this.accountName + '.cartodb.com/api/v2/sql?q=' + query;
+    url = '//' + this.accountName + '.cartodb.com/api/v2/sql?q=' + query;
     if (this.apiKey) url += '&api_key=' + this.apiKey;
     return url;
   },


### PR DESCRIPTION
If an app is being served over https, it will throw a mixed content error. This makes it protocol agnostic.
